### PR TITLE
String enhancements

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -9,6 +9,7 @@ This is Lua 5.0 FAF version.
   + new single line comment: # ...
   + new binary operators &, |, << and >>
   + operator ^ means xor instead of pow
+  + metatable for strings pointing at `string' library
   Implementation:
   + skip BOM and unix style # comments when reading files
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The most notable changes are:
 - Bash style single line `#` comments
 - Bitwise operators `&`, `|`, `<<`, and `>>`
 - Pow operator replaced by bitwise xor `^`
+- String methods available on strings. i.e. `str:sub(2)`
 
 See [HISTORY](HISTORY) for a full list of changes.
 

--- a/src/lapi.c
+++ b/src/lapi.c
@@ -534,6 +534,9 @@ LUA_API int lua_getmetatable (lua_State *L, int objindex) {
       case LUA_TUSERDATA:
         mt = uvalue(obj)->uv.metatable;
         break;
+      default:
+        mt = G(L)->mt[ttype(obj)];
+        break;
     }
   }
   if (mt == NULL || mt == hvalue(defaultmeta(L)))
@@ -616,7 +619,7 @@ LUA_API int lua_setmetatable (lua_State *L, int objindex) {
       break;
     }
     default: {
-      res = 0;  /* cannot set */
+      G(L)->mt[ttype(obj)] = hvalue(mt);
       break;
     }
   }
@@ -919,4 +922,3 @@ LUA_API const char *lua_setupvalue (lua_State *L, int funcindex, int n) {
   lua_unlock(L);
   return name;
 }
-

--- a/src/lgc.c
+++ b/src/lgc.c
@@ -450,12 +450,21 @@ void luaC_sweep (lua_State *L, int all) {
 }
 
 
+static void markmt (GCState *st) {
+  int i;
+  global_State *g = st->g;
+  for (i=0; i<NUM_TAGS; i++)
+    if (g->mt[i]) markvalue(st, g->mt[i]);
+}
+
+
 /* mark root set */
 static void markroot (GCState *st, lua_State *L) {
   global_State *g = st->g;
   markobject(st, defaultmeta(L));
   markobject(st, registry(L));
   traversestack(st, g->mainthread);
+  markmt(st);
   if (L != g->mainthread)  /* another thread is running? */
     markvalue(st, L);  /* cannot collect it */
 }
@@ -502,4 +511,3 @@ void luaC_link (lua_State *L, GCObject *o, lu_byte tt) {
   o->gch.marked = 0;
   o->gch.tt = tt;
 }
-

--- a/src/lib/lstrlib.c
+++ b/src/lib/lstrlib.c
@@ -760,11 +760,22 @@ static const luaL_reg strlib[] = {
 };
 
 
+static void createmetatable (lua_State *L) {
+  lua_newtable(L);  /* create metatable for strings */
+  lua_pushliteral(L, "__index");  /* dummy string, but also the metamethod */
+  lua_pushvalue(L, -2);
+  lua_setmetatable(L, -2);  /* set string metatable */
+  lua_pushvalue(L, -3);  /* string library... */
+  lua_settable(L, -3);  /* ...is the __index metamethod */
+  lua_pop(L, 1);  /* pop metatable */
+}
+
+
 /*
 ** Open string library
 */
 LUALIB_API int luaopen_string (lua_State *L) {
   luaL_openlib(L, LUA_STRLIBNAME, strlib, 0);
+  createmetatable(L);
   return 1;
 }
-

--- a/src/lib/lstrlib.c
+++ b/src/lib/lstrlib.c
@@ -743,6 +743,12 @@ static int str_format (lua_State *L) {
 }
 
 
+static int str_lualex (lua_State *L) {
+  // TODO: Implement
+  return 1;
+}
+
+
 static const luaL_reg strlib[] = {
   {"len", str_len},
   {"sub", str_sub},
@@ -756,6 +762,7 @@ static const luaL_reg strlib[] = {
   {"find", str_find},
   {"gfind", gfind},
   {"gsub", str_gsub},
+  {"lualex", str_lualex},
   {NULL, NULL}
 };
 

--- a/src/lstate.c
+++ b/src/lstate.c
@@ -88,6 +88,7 @@ static void freestack (lua_State *L, lua_State *L1) {
 */
 static void f_luaopen (lua_State *L, void *ud) {
   /* create a new global state */
+  int i;
   global_State *g = luaM_new(NULL, global_State);
   UNUSED(ud);
   if (g == NULL) luaD_throw(L, LUA_ERRMEM);
@@ -108,6 +109,7 @@ static void f_luaopen (lua_State *L, void *ud) {
   setnilvalue(gval(g->dummynode));
   g->dummynode->next = NULL;
   g->nblocks = sizeof(lua_State) + sizeof(global_State);
+  for (i=0; i<NUM_TAGS; i++) g->mt[i] = NULL;
   stack_init(L, L);  /* init stack */
   /* create default meta table with a dummy table, and then close the loop */
   defaultmeta(L)->tt = LUA_TTABLE;
@@ -217,4 +219,3 @@ LUA_API void lua_close (lua_State *L) {
   lua_assert(G(L)->tmudata == NULL);
   close_state(L);
 }
-

--- a/src/lstate.h
+++ b/src/lstate.h
@@ -22,7 +22,7 @@
 ** a thread must also synchronize any write-access to its own stack.
 ** Unsynchronized accesses are allowed only when reading its own stack,
 ** or when reading immutable fields from global objects
-** (such as string values and udata values). 
+** (such as string values and udata values).
 */
 #ifndef lua_lock
 #define lua_lock(L)	((void) 0)
@@ -121,6 +121,7 @@ typedef struct global_State {
   TObject _defaultmeta;
   struct lua_State *mainthread;
   Node dummynode[1];  /* common node array for all empty tables */
+  struct Table *mt[NUM_TAGS];  /* metatables for basic types */
   TString *tmname[TM_N];  /* array with tag-method names */
 } global_State;
 
@@ -192,4 +193,3 @@ lua_State *luaE_newthread (lua_State *L);
 void luaE_freethread (lua_State *L, lua_State *L1);
 
 #endif
-

--- a/src/ltm.c
+++ b/src/ltm.c
@@ -57,14 +57,16 @@ const TObject *luaT_gettm (Table *events, TMS event, TString *ename) {
 
 
 const TObject *luaT_gettmbyobj (lua_State *L, const TObject *o, TMS event) {
-  TString *ename = G(L)->tmname[event];
+  Table *mt;
   switch (ttype(o)) {
     case LUA_TTABLE:
-      return luaH_getstr(hvalue(o)->metatable, ename);
+      mt = hvalue(o)->metatable;
+      break;
     case LUA_TUSERDATA:
-      return luaH_getstr(uvalue(o)->uv.metatable, ename);
+      mt = uvalue(o)->uv.metatable;
+      break;
     default:
-      return &luaO_nilobject;
+      mt = G(L)->mt[ttype(o)];
   }
+  return (mt ? luaH_getstr(mt, G(L)->tmname[event]) : &luaO_nilobject);
 }
-

--- a/test/faf.lua
+++ b/test/faf.lua
@@ -120,6 +120,8 @@ assert(str:sub(2) == "bcdefghijklmnop")
 assert(str:sub(2, -2) == "bcdefghijklmno")
 assert(str:sub(2, 8) == "bcdefgh")
 
+assert(str:lualex() == str)
+
 local string_func_names = {}
 local n=0
 
@@ -129,6 +131,7 @@ for k in string do
 end
 assert(table.concat(string_func_names) == table.concat({
   "sub",
+  "lualex",
   "gfind",
   "rep",
   "gsub",

--- a/test/faf.lua
+++ b/test/faf.lua
@@ -113,3 +113,33 @@ for _, b in pairs(c) do
   print("  passed " .. b)
 end
 print("passed binary operators")
+
+str = "abcdefghijklmnop"
+assert(str:sub(-2) == "op")
+assert(str:sub(2) == "bcdefghijklmnop")
+assert(str:sub(2, -2) == "bcdefghijklmno")
+assert(str:sub(2, 8) == "bcdefgh")
+
+local string_func_names = {}
+local n=0
+
+for k in string do
+  n=n+1
+  string_func_names[n]=k
+end
+assert(table.concat(string_func_names) == table.concat({
+  "sub",
+  "gfind",
+  "rep",
+  "gsub",
+  "char",
+  "dump",
+  "find",
+  "upper",
+  "len",
+  "format",
+  "byte",
+  "lower"
+}))
+
+print("passed string library")


### PR DESCRIPTION
Add metatables for basic types copied over from the lua 5.1 implementation and use it to set the `string` library as `__index` for string types. The implementation isn't exactly like it is in FA because it uses the lua API to do it instead of reaching into the lua internals like the GPG guys did.

Also adds a placeholder implementation for `lualex`, that probably works much the same as the actual `lualex` does in many situations...

Closes #1 
Adds dummy for #2