### PR TITLE
Add support for table prealloc syntax

### DIFF
--- a/test/faf.lua
+++ b/test/faf.lua
@@ -146,3 +146,8 @@ assert(table.concat(string_func_names) == table.concat({
 }))
 
 print("passed string library")
+
+prealloc_t = {&5};
+prealloc_t = {&5 &1};
+
+print("passed const construction of a table")


### PR DESCRIPTION
Closes #7
### Brief
I've implemented support for table prealocation syntax.
New grammar allows to produce 
- table = `{&A &B}`
- table = `{&A}`